### PR TITLE
Bearer tokens

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -706,6 +706,17 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 		saveSession = true
 	}
 
+	authHeader := req.Header.Get("Authorization")
+	if authHeader != "" {
+		log.Printf("Authorization header: %s,", authHeader)
+		session = &providers.SessionState{IdToken: authHeader[7:]}
+		// Strip of the 'Bearer ' section of the header
+		session.Email, err = p.provider.GetEmailAddress(session)
+		session.User, err = p.provider.GetUserName(session)
+		log.Printf("User Session from Bearer Token: %s%", session)
+	}
+
+
 	if ok, err := p.provider.RefreshSessionIfNeeded(session); err != nil {
 		log.Printf("%s removing session. error refreshing access token %s %s", remoteAddr, err, session)
 		clearSession = true

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -702,9 +702,9 @@ func (p *OAuthProxy) Authenticate(rw http.ResponseWriter, req *http.Request) int
 	remoteAddr := getRemoteAddr(req)
 
 	authHeader := req.Header.Get("Authorization")
-	if authHeader != "" {
+	if strings.Contains(strings.ToLower(authHeader), "bearer") {
 		var err error
-		session, err = AuthenticateViaAuthorizationHeader(authHeader, p.provider)
+		session, err = AuthenticateViaBearerToken(authHeader, p.provider)
 		if err != nil {
 			return http.StatusForbidden
 		}
@@ -820,7 +820,7 @@ func AuthenticateViaLogin(p *OAuthProxy, req *http.Request, remoteAddr string, r
 	return session, statusCode
 }
 
-func AuthenticateViaAuthorizationHeader(authHeader string, provider providers.Provider) (*providers.SessionState, error) {
+func AuthenticateViaBearerToken(authHeader string, provider providers.Provider) (*providers.SessionState, error) {
 	log.Printf("Authorization header: %s,", authHeader)
 	var err error
 	session := &providers.SessionState{IdToken: authHeader[7:]}

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -833,7 +833,7 @@ func AuthenticateViaBearerToken(authHeader string, provider providers.Provider) 
 	if session.User == "" && session.Email != "" {
 		session.User = strings.Split(session.Email, "@")[0]
 	}
-	log.Printf("User Session from Bearer Token: %s%", session)
+	log.Printf("User Session from Bearer Token: %s", session)
 	return session, nil
 }
 

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -818,6 +818,9 @@ func AuthenticateViaAuthorizationHeader(authHeader string, provider providers.Pr
 	// Strip of the 'Bearer ' section of the header
 	session.Email, _ = provider.GetEmailAddress(session)
 	session.User, _ = provider.GetUserName(session)
+	if session.User == "" && session.Email != "" {
+		session.User = strings.Split(session.Email, "@")[0]
+	}
 	log.Printf("User Session from Bearer Token: %s%", session)
 	return session
 }

--- a/providers/google.go
+++ b/providers/google.go
@@ -89,6 +89,10 @@ func emailFromIdToken(idToken string) (string, error) {
 	return email.Email, nil
 }
 
+func (p *GoogleProvider) GetEmailAddress(s *SessionState) (string, error) {
+	return emailFromIdToken(s.IdToken)
+}
+
 func (p *GoogleProvider) Redeem(redirectURL, code string) (s *SessionState, err error) {
 	if code == "" {
 		err = errors.New("missing code")

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -85,7 +85,9 @@ func (p *OIDCProvider) GetEmailAddress(s *SessionState) (string, error) {
 	//	Verified *bool  `json:"email_verified"`
 	//}
 	claims := Claims{}
-	err = idToken.Claims(&claims)
+	if err == nil {
+		err = idToken.Claims(&claims)
+	}
 	return claims.Email, err
 }
 

--- a/providers/oidc.go
+++ b/providers/oidc.go
@@ -91,17 +91,6 @@ func (p *OIDCProvider) GetEmailAddress(s *SessionState) (string, error) {
 	return claims.Email, err
 }
 
-//func (p *OIDCProvider) GetUserName(s *SessionState) (string, error) {
-//	ctx := context.Background()
-//	idToken, err := p.Verifier.Verify(ctx, s.IdToken)
-//
-//	var claims struct {
-//		Name    string `json:"name"`
-//	}
-//	err = idToken.Claims(&claims)
-//	return claims.Name, err
-//}
-
 func (p *OIDCProvider) RefreshSessionIfNeeded(s *SessionState) (bool, error) {
 	if s == nil || s.ExpiresOn.After(time.Now()) || s.RefreshToken == "" {
 		return false, nil


### PR DESCRIPTION
The ability to pass a bearer token (the User's JWT from Dex) as the `Authorization` header in requests.
The auth proxy will then verify the user's identity from this JWT instead of using their cookie/login.

The idea behind this is that browser requests (or CORS requests) can be logged in to one app (via Dex) and get a JWT for a CORS request to a second site (which also uses Dex) using this token, without having to be prompted to login at the second site as well as the first.
